### PR TITLE
Set up action for set-product-version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,44 +1,42 @@
-
 name: set-product-version
 author: Release Engineering <rel-eng@hashicorp.com>
 description: Automates setting product version
 
 env:
-  VERSION_FILE: .release/VERSION
+  VERSION_FILE: ${{ .release/VERSION }}
 
-  runs:
-    using: composite
+runs:
+  using: composite
 
-  jobs:
-    get-product-version:
-      runs-on: ubuntu-latest
-      outputs:
-        product-version: ${{ steps.get-product-version.outputs.product-version }}
-      steps:
-        - name: Check if Version File Exists
-          uses: actions/checkout@v3
-          shell: bash
-          run: |
-            FILE=$1
-            if [ -f ${VERSION_FILE}]; then
-              echo "File ${VERSION_FILE} exists."
-            else
-              echo "File ${VERSION_FILE} does not exist."
-            fi
+  steps:
+    - name: Check if Version File Exists
+      uses: actions/checkout@v3
+      shell: bash
+      run: |
+        FILE=$1
+        if [ -f ${VERSION_FILE}]; then
+          echo "File ${VERSION_FILE} exists."
+        else
+          echo "File ${VERSION_FILE} does not exist."
+        fi
 
-        - name: Set Product Version
-          id: set-product-version
-          uses: actions/checkout@v3
-          shell: bash
-          run: |
-            product_version=$(<.release/VERSION)
-            echo "$product_version"
-            whitespace=" |'"
+    - name: Set Product Version
+      uses: actions/checkout@v3
+      shell: bash
+      run: |
+        product_version=$(<.release/VERSION)
+        echo "$product_version"
+        whitespace=" |'"
 
-            if ["$product_version" =~ $whitespace]; then
-              echo "Whitespace detected in version string! Trimming down."
-              echo "$product_version | sed 's/ //g'"
-              product_version=$(echo "$product_version" | sed 's/ //g')
-            else
-              echo "No whitespace found in ${product_version}!"
-            fi
+        if ["$product_version" =~ $whitespace]; then
+          echo "Whitespace detected in version string! Trimming down."
+          echo "$product_version | sed 's/ //g'"
+          product_version=$(echo "$product_version" | sed 's/ //g')
+        else
+          echo "No whitespace found in ${product_version}!"
+        fi
+
+    - name: Set output
+      uses: actions/checkout@v3
+      shell: bash
+      run: echo "{product_version}={product_version}" >> GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ runs:
         if [ -f ${VERSION_FILE}]; then
           echo "File ${VERSION_FILE} exists."
         else
-          echo "File ${VERSION_FILE} does not exist."
+          echo "File ${VERSION_FILE} does not exist. Please add a VERSION file in the .release/ directory"
         fi
 
     - name: Set Product Version

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,44 @@
+
+name: set-product-version
+author: Release Engineering <rel-eng@hashicorp.com>
+description: Automates setting product version
+
+env:
+  VERSION_FILE: .release/VERSION
+
+  runs:
+    using: composite
+
+  jobs:
+    get-product-version:
+      runs-on: ubuntu-latest
+      outputs:
+        product-version: ${{ steps.get-product-version.outputs.product-version }}
+      steps:
+        - name: Check if Version File Exists
+          uses: actions/checkout@v3
+          shell: bash
+          run: |
+            FILE=$1
+            if [ -f ${VERSION_FILE}]; then
+              echo "File ${VERSION_FILE} exists."
+            else
+              echo "File ${VERSION_FILE} does not exist."
+            fi
+
+        - name: Set Product Version
+          id: set-product-version
+          uses: actions/checkout@v3
+          shell: bash
+          run: |
+            product_version=$(<.release/VERSION)
+            echo "$product_version"
+            whitespace=" |'"
+
+            if ["$product_version" =~ $whitespace]; then
+              echo "Whitespace detected in version string! Trimming down."
+              echo "$product_version | sed 's/ //g'"
+              product_version=$(echo "$product_version" | sed 's/ //g')
+            else
+              echo "No whitespace found in ${product_version}!"
+            fi


### PR DESCRIPTION
This PR contains the code for the new set-product-version action. We check if .release/VERSION file exists, and if it does then we read the file's contents, version string in our case. We also check if there's whitespace and if there is, we trim the version string. 
