### PR TITLE
RELENG-245: Create reusable action to set product version from .release/VERSION file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,33 @@
+name: set-product-version
+author: Release Engineering <rel-eng@hashicorp.com>
+description: Automates setting product version
+
+
+runs:
+  using: composite
+
+  steps:
+    - uses: actions/checkout@v3
+    - name: Check if Version File Exists
+      shell: bash
+      env:
+        VERSION_FILE: .release/VERSION
+      run: |
+        if [ -f $VERSION_FILE ]; then
+          echo "File ${VERSION_FILE} exists."
+        else
+          echo "File ${VERSION_FILE} does not exist. Please add a VERSION file in the .release/ directory"
+        fi
+    - name: Set Product Version
+      id: set-product-version
+      shell: bash
+      run: |
+        product_version=$(<.release/VERSION)
+        product_version=$(echo "$product_version" | sed 's/ //g')
+        echo "Product Version: $product_version"
+        echo "product-version=$product_version" >> $GITHUB_OUTPUT
+
+outputs:
+  product-version:
+    description: 'The product version'
+    value: ${{ steps.set-product-version.outputs.product-version }}


### PR DESCRIPTION
This PR includes a reusable actions that sets the product-version using a `.release/VERSION` file. The contents of this file are only the release and pre-release fields for a product.

This action is meant to be used by all product repos in the effort to move teams from using a variety of different methods of calculating their product-versions to using a single source of truth for product versions: `.release/VERSION`, and is part of a larger effort for version bump automation.

This action was tested in the dev org's `helloworld` repo, with three distinct test cases:
1. no version file: https://github.com/HashiCorp-RelEng-Dev/crt-core-helloworld/actions/runs/3464779899/jobs/5786728686
2. whitespace: https://github.com/HashiCorp-RelEng-Dev/crt-core-helloworld/actions/runs/3464762792/jobs/5786687280
3. happy path: https://github.com/HashiCorp-RelEng-Dev/crt-core-helloworld/actions/runs/3464612396/jobs/5786340768