### PR TITLE
Add outputs for prerelease and base product version strings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
         else
           echo "File ${VERSION_FILE} does not exist. Please add a VERSION file in the .release/ directory"
         fi
-    - name: Set Product Version
+    - name: Set Full Product Version
       id: set-product-version
       shell: bash
       run: |
@@ -26,8 +26,36 @@ runs:
         product_version=$(echo "$product_version" | sed 's/ //g')
         echo "Product Version: $product_version"
         echo "product-version=$product_version" >> $GITHUB_OUTPUT
+    # Examples
+    # When product_version = 1.3.0-alpha1, base_product_version = 1.3.0
+    - name: Set Base Product Version
+      id: set-base-product-version
+      shell: bash
+      run: |
+        product_version=$(<.release/VERSION)
+        product_version=$(echo "$product_version" | sed 's/ //g')
+        base_product_version=${product_version%%-*}
+        echo "Base Product Version: $base_product_version"
+        echo "base-product-version=$base_product_version" >> $GITHUB_OUTPUT
+    # Examples
+    # When product_version = 1.3.0-alpha1, prerelease_product_version = alpha1
+    - name: Set Prerelease Product Version
+      id: set-prerelease-product-version
+      shell: bash
+      run: |
+        product_version=$(<.release/VERSION)
+        product_version=$(echo "$product_version" | sed 's/ //g')
+        prerelease_product_version=${product_version#*-}
+        echo "Prerelease Product Version: $prerelease_product_version"
+        echo "prerelease-product-version=$prerelease_product_version" >> $GITHUB_OUTPUT
 
 outputs:
   product-version:
     description: 'The product version'
     value: ${{ steps.set-product-version.outputs.product-version }}
+  prerelease-product-version:
+    description: 'The prerelease portion of the product version'
+    value: ${{ steps.set-product-version.outputs.prerelease-product-version }}
+  base-product-version:
+    description: 'The base portion of the product version'
+    value: ${{ steps.set-product-version.outputs.base-product-version }}


### PR DESCRIPTION
This way we can access these outputs (base and prerelease) without needing to do the processing on product_version within each build.yml workflow. 