### PR TITLE
Allow optional code checkout

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,12 +2,18 @@ name: set-product-version
 author: Release Engineering <rel-eng@hashicorp.com>
 description: Automates setting product version
 
+inputs:
+  checkout:
+    description: |
+      Check out the code repository. Can be disabled if checkout is handled by the caller workflow.
+    default: true
 
 runs:
   using: composite
 
   steps:
-    - uses: actions/checkout@v3
+    - if: inputs.checkout == 'true'
+      uses: actions/checkout@v3
     - name: Check if Version File Exists
       shell: bash
       env:


### PR DESCRIPTION
Allow disabling the code checkout to allow caller workflows to control the checkout reference used when determining product version metadata.

We'd like to be able to do this in Vault so that we can specify the Git reference we'd like to use instead of always using the default github reference for the trigger event.

