### PR TITLE
update actions/checkout with TSCCR from node16->20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ runs:
 
   steps:
     - if: inputs.checkout == 'true'
-      uses: actions/checkout@v3
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - name: Check if Version File Exists
       shell: bash
       env:


### PR DESCRIPTION
Closes https://github.com/hashicorp/releng-support/issues/297.

This PR updates actions/checkout@v3 to v4 for node16 deprecation warnings. 