### PR TITLE
Update internal github action workflows to avoid the Node 20 deprecat…

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ runs:
 
   steps:
     - if: inputs.checkout == 'true'
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Check if Version File Exists
       shell: bash
       env:


### PR DESCRIPTION
Updated internal github action workflows to avoid the Node 20 deprecation warning

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
